### PR TITLE
fix: remove repeated prompts

### DIFF
--- a/showshowway/__init__.py
+++ b/showshowway/__init__.py
@@ -38,4 +38,4 @@ def give_skull(server, info):
 
 def show_item(server, json):
 	server.execute('tellraw @a {}'.format(json))
-	server.execute('execute at @a run playsound minecraft:entity.arrow.hit_player player @a')
+    server.execute('execute run playsound minecraft:entity.arrow.hit_player player @a')


### PR DESCRIPTION
当前版本中，当玩家使用 `!!show` 指令时，会产生多个“已将声音minecraft: entity.arrow.hit_player播放给x名玩家”的提示。

当服务器内存在N个玩家的时候，这条提示会重复N次。

本次 pull request 解决了这一问题，修复后每个玩家只会收到一次该提示信息。